### PR TITLE
Fix code scanning alert no. 2: Binding a socket to all network interfaces

### DIFF
--- a/app/utils/udp_manager.py
+++ b/app/utils/udp_manager.py
@@ -47,7 +47,7 @@ class UDPManager:
             port = s.getsockname()[1]
             # Ensure the port is not already used in the manager
             while port in self.used_ports:
-                s.bind(('', 0))
+                s.bind((self.interface, 0))
                 port = s.getsockname()[1]
             return port
 


### PR DESCRIPTION
Fixes [https://github.com/mfreder7/Zoro-GSF_Multiplayer-Framework/security/code-scanning/2](https://github.com/mfreder7/Zoro-GSF_Multiplayer-Framework/security/code-scanning/2)

To fix the problem, we need to ensure that the socket is bound to a specific interface instead of all interfaces when finding a free port. This can be achieved by replacing the empty string `''` with `self.interface` on line 50. This change will ensure that the socket is only bound to the specified interface, maintaining consistency and improving security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
